### PR TITLE
Multiple mapping contexts

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,6 @@ version = "0.4.6"
 authors = ["MaidSafe Developers <dev@maidsafe.net>"]
 
 [dependencies]
-lazy_static = "~0.2.9"
 tokio-io = "~0.1.3"
 tokio-core = "~0.1.10"
 futures = "~0.1.17"

--- a/examples/tcp_listener.rs
+++ b/examples/tcp_listener.rs
@@ -15,8 +15,9 @@ use tokio_core::net::TcpListener;
 fn main() {
     let mut core = unwrap!(tokio_core::reactor::Core::new());
     let handle = core.handle();
+    let mut mc = p2p::Mc::default();
     let res = core.run({
-        TcpListener::bind_public(&addr!("0.0.0.0:0"), &handle)
+        TcpListener::bind_public(&addr!("0.0.0.0:0"), &handle, &mut mc)
             .map_err(|e| panic!("Error binding listener publicly: {}", e))
             .and_then(|(listener, public_addr)| {
                 println!("listening on public socket address {}", public_addr);

--- a/examples/tcp_listener.rs
+++ b/examples/tcp_listener.rs
@@ -15,7 +15,7 @@ use tokio_core::net::TcpListener;
 fn main() {
     let mut core = unwrap!(tokio_core::reactor::Core::new());
     let handle = core.handle();
-    let mut mc = p2p::Mc::default();
+    let mut mc = p2p::P2p::default();
     let res = core.run({
         TcpListener::bind_public(&addr!("0.0.0.0:0"), &handle, &mut mc)
             .map_err(|e| panic!("Error binding listener publicly: {}", e))

--- a/examples/tcp_listener.rs
+++ b/examples/tcp_listener.rs
@@ -15,9 +15,9 @@ use tokio_core::net::TcpListener;
 fn main() {
     let mut core = unwrap!(tokio_core::reactor::Core::new());
     let handle = core.handle();
-    let mut mc = p2p::P2p::default();
+    let mc = p2p::P2p::default();
     let res = core.run({
-        TcpListener::bind_public(&addr!("0.0.0.0:0"), &handle, &mut mc)
+        TcpListener::bind_public(&addr!("0.0.0.0:0"), &handle, &mc)
             .map_err(|e| panic!("Error binding listener publicly: {}", e))
             .and_then(|(listener, public_addr)| {
                 println!("listening on public socket address {}", public_addr);

--- a/examples/tcp_rendezvous_connect.rs
+++ b/examples/tcp_rendezvous_connect.rs
@@ -103,7 +103,7 @@ fn main() {
             .unwrap_or_else(|e| e.exit())
     };
 
-    let mut mc = p2p::P2p::default();
+    let mc = p2p::P2p::default();
     if args.flag_disable_igd {
         mc.disable_igd();
     }
@@ -123,7 +123,7 @@ fn main() {
             .and_then(move |relay_stream| {
                 let relay_channel =
                     DummyDebug(Framed::new(relay_stream).map(|bytes| bytes.freeze()));
-                TcpStream::rendezvous_connect(relay_channel, &handle, &mut mc)
+                TcpStream::rendezvous_connect(relay_channel, &handle, &mc)
                     .map_err(|e| panic!("rendezvous connect failed: {}", e))
                     .and_then(|stream| {
                         println!("connected!");

--- a/examples/tcp_rendezvous_connect.rs
+++ b/examples/tcp_rendezvous_connect.rs
@@ -103,7 +103,7 @@ fn main() {
             .unwrap_or_else(|e| e.exit())
     };
 
-    let mut mc = p2p::Mc::default();
+    let mut mc = p2p::P2p::default();
     if args.flag_disable_igd {
         mc.disable_igd();
     }

--- a/examples/tcp_rendezvous_connect.rs
+++ b/examples/tcp_rendezvous_connect.rs
@@ -103,12 +103,13 @@ fn main() {
             .unwrap_or_else(|e| e.exit())
     };
 
+    let mut mc = p2p::Mc::default();
     if args.flag_disable_igd {
-        p2p::disable_igd();
+        mc.disable_igd();
     }
 
     if let Some(server) = args.flag_traversal_server {
-        p2p::add_tcp_traversal_server(&server);
+        mc.add_tcp_traversal_server(&server);
     }
 
     let relay_addr = args.flag_relay;
@@ -122,7 +123,7 @@ fn main() {
             .and_then(move |relay_stream| {
                 let relay_channel =
                     DummyDebug(Framed::new(relay_stream).map(|bytes| bytes.freeze()));
-                TcpStream::rendezvous_connect(relay_channel, &handle)
+                TcpStream::rendezvous_connect(relay_channel, &handle, &mut mc)
                     .map_err(|e| panic!("rendezvous connect failed: {}", e))
                     .and_then(|stream| {
                         println!("connected!");

--- a/examples/tcp_rendezvous_server.rs
+++ b/examples/tcp_rendezvous_server.rs
@@ -12,8 +12,9 @@ use p2p::TcpRendezvousServer;
 fn main() {
     let mut core = unwrap!(tokio_core::reactor::Core::new());
     let handle = core.handle();
+    let mut mc = p2p::Mc::default();
     let res = core.run({
-        TcpRendezvousServer::bind_public(&addr!("0.0.0.0:0"), &handle)
+        TcpRendezvousServer::bind_public(&addr!("0.0.0.0:0"), &handle, &mut mc)
             .map_err(|e| panic!("Error binding server publicly: {}", e))
             .and_then(|(server, public_addr)| {
                 println!("listening on public socket address {}", public_addr);

--- a/examples/tcp_rendezvous_server.rs
+++ b/examples/tcp_rendezvous_server.rs
@@ -12,9 +12,9 @@ use p2p::TcpRendezvousServer;
 fn main() {
     let mut core = unwrap!(tokio_core::reactor::Core::new());
     let handle = core.handle();
-    let mut mc = p2p::P2p::default();
+    let mc = p2p::P2p::default();
     let res = core.run({
-        TcpRendezvousServer::bind_public(&addr!("0.0.0.0:0"), &handle, &mut mc)
+        TcpRendezvousServer::bind_public(&addr!("0.0.0.0:0"), &handle, &mc)
             .map_err(|e| panic!("Error binding server publicly: {}", e))
             .and_then(|(server, public_addr)| {
                 println!("listening on public socket address {}", public_addr);

--- a/examples/tcp_rendezvous_server.rs
+++ b/examples/tcp_rendezvous_server.rs
@@ -12,7 +12,7 @@ use p2p::TcpRendezvousServer;
 fn main() {
     let mut core = unwrap!(tokio_core::reactor::Core::new());
     let handle = core.handle();
-    let mut mc = p2p::Mc::default();
+    let mut mc = p2p::P2p::default();
     let res = core.run({
         TcpRendezvousServer::bind_public(&addr!("0.0.0.0:0"), &handle, &mut mc)
             .map_err(|e| panic!("Error binding server publicly: {}", e))

--- a/examples/udp_bind_public.rs
+++ b/examples/udp_bind_public.rs
@@ -18,9 +18,9 @@ use void::ResultVoidExt;
 fn main() {
     let mut core = unwrap!(tokio_core::reactor::Core::new());
     let handle = core.handle();
-    let mut mc = p2p::P2p::default();
+    let mc = p2p::P2p::default();
     let res = core.run({
-        UdpSocket::bind_public(&addr!("0.0.0.0:0"), &handle, &mut mc)
+        UdpSocket::bind_public(&addr!("0.0.0.0:0"), &handle, &mc)
             .map_err(|e| panic!("Error binding socket publicly: {}", e))
             .and_then(|(socket, public_addr)| {
                 println!(

--- a/examples/udp_bind_public.rs
+++ b/examples/udp_bind_public.rs
@@ -18,7 +18,7 @@ use void::ResultVoidExt;
 fn main() {
     let mut core = unwrap!(tokio_core::reactor::Core::new());
     let handle = core.handle();
-    let mut mc = p2p::Mc::default();
+    let mut mc = p2p::P2p::default();
     let res = core.run({
         UdpSocket::bind_public(&addr!("0.0.0.0:0"), &handle, &mut mc)
             .map_err(|e| panic!("Error binding socket publicly: {}", e))

--- a/examples/udp_bind_public.rs
+++ b/examples/udp_bind_public.rs
@@ -18,8 +18,9 @@ use void::ResultVoidExt;
 fn main() {
     let mut core = unwrap!(tokio_core::reactor::Core::new());
     let handle = core.handle();
+    let mut mc = p2p::Mc::default();
     let res = core.run({
-        UdpSocket::bind_public(&addr!("0.0.0.0:0"), &handle)
+        UdpSocket::bind_public(&addr!("0.0.0.0:0"), &handle, &mut mc)
             .map_err(|e| panic!("Error binding socket publicly: {}", e))
             .and_then(|(socket, public_addr)| {
                 println!(

--- a/examples/udp_rendezvous_connect.rs
+++ b/examples/udp_rendezvous_connect.rs
@@ -104,7 +104,7 @@ fn main() {
             .unwrap_or_else(|e| e.exit())
     };
 
-    let mut mc = p2p::P2p::default();
+    let mc = p2p::P2p::default();
     if args.flag_disable_igd {
         mc.disable_igd();
     }
@@ -124,7 +124,7 @@ fn main() {
             .and_then(move |relay_stream| {
                 let relay_channel =
                     DummyDebug(Framed::new(relay_stream).map(|bytes| bytes.freeze()));
-                UdpSocket::rendezvous_connect(relay_channel, &handle, &mut mc)
+                UdpSocket::rendezvous_connect(relay_channel, &handle, &mc)
                     .map_err(|e| panic!("rendezvous connect failed: {}", e))
                     .and_then(|(socket, addr)| {
                         println!("connected!");

--- a/examples/udp_rendezvous_connect.rs
+++ b/examples/udp_rendezvous_connect.rs
@@ -104,7 +104,7 @@ fn main() {
             .unwrap_or_else(|e| e.exit())
     };
 
-    let mut mc = p2p::Mc::default();
+    let mut mc = p2p::P2p::default();
     if args.flag_disable_igd {
         mc.disable_igd();
     }

--- a/examples/udp_rendezvous_connect.rs
+++ b/examples/udp_rendezvous_connect.rs
@@ -104,12 +104,13 @@ fn main() {
             .unwrap_or_else(|e| e.exit())
     };
 
+    let mut mc = p2p::Mc::default();
     if args.flag_disable_igd {
-        p2p::disable_igd();
+        mc.disable_igd();
     }
 
     if let Some(server) = args.flag_traversal_server {
-        p2p::add_udp_traversal_server(&server);
+        mc.add_udp_traversal_server(&server);
     }
 
     let relay_addr = args.flag_relay;
@@ -123,7 +124,7 @@ fn main() {
             .and_then(move |relay_stream| {
                 let relay_channel =
                     DummyDebug(Framed::new(relay_stream).map(|bytes| bytes.freeze()));
-                UdpSocket::rendezvous_connect(relay_channel, &handle)
+                UdpSocket::rendezvous_connect(relay_channel, &handle, &mut mc)
                     .map_err(|e| panic!("rendezvous connect failed: {}", e))
                     .and_then(|(socket, addr)| {
                         println!("connected!");

--- a/examples/udp_rendezvous_server.rs
+++ b/examples/udp_rendezvous_server.rs
@@ -24,8 +24,9 @@ use p2p::UdpRendezvousServer;
 fn main() {
     let mut core = unwrap!(tokio_core::reactor::Core::new());
     let handle = core.handle();
+    let mut mc = p2p::Mc::default();
     let res = core.run({
-        UdpRendezvousServer::bind_public(&addr!("0.0.0.0:0"), &handle)
+        UdpRendezvousServer::bind_public(&addr!("0.0.0.0:0"), &handle, &mut mc)
             .map_err(|e| panic!("Error binding server publicly: {}", e))
             .and_then(|(server, public_addr)| {
                 println!("listening on public socket address {}", public_addr);

--- a/examples/udp_rendezvous_server.rs
+++ b/examples/udp_rendezvous_server.rs
@@ -24,7 +24,7 @@ use p2p::UdpRendezvousServer;
 fn main() {
     let mut core = unwrap!(tokio_core::reactor::Core::new());
     let handle = core.handle();
-    let mut mc = p2p::Mc::default();
+    let mut mc = p2p::P2p::default();
     let res = core.run({
         UdpRendezvousServer::bind_public(&addr!("0.0.0.0:0"), &handle, &mut mc)
             .map_err(|e| panic!("Error binding server publicly: {}", e))

--- a/examples/udp_rendezvous_server.rs
+++ b/examples/udp_rendezvous_server.rs
@@ -24,9 +24,9 @@ use p2p::UdpRendezvousServer;
 fn main() {
     let mut core = unwrap!(tokio_core::reactor::Core::new());
     let handle = core.handle();
-    let mut mc = p2p::P2p::default();
+    let mc = p2p::P2p::default();
     let res = core.run({
-        UdpRendezvousServer::bind_public(&addr!("0.0.0.0:0"), &handle, &mut mc)
+        UdpRendezvousServer::bind_public(&addr!("0.0.0.0:0"), &handle, &mc)
             .map_err(|e| panic!("Error binding server publicly: {}", e))
             .and_then(|(server, public_addr)| {
                 println!("listening on public socket address {}", public_addr);

--- a/src/igd_async.rs
+++ b/src/igd_async.rs
@@ -138,7 +138,7 @@ pub fn get_any_address_rendezvous(
     local_addr: SocketAddr,
     timeout: Duration,
     handle: &Handle,
-    mc: &Mc,
+    mc: &P2p,
 ) -> BoxFuture<SocketAddr, GetAnyAddressError> {
     if !mc.is_igd_enabled_for_rendezvous() {
         return future::err(GetAnyAddressError::Disabled).into_boxed();
@@ -153,7 +153,7 @@ pub fn get_any_address_open(
     protocol: Protocol,
     local_addr: SocketAddr,
     handle: &Handle,
-    mc: &Mc,
+    mc: &P2p,
 ) -> BoxFuture<SocketAddr, GetAnyAddressError> {
     get_any_address(protocol, local_addr, None, handle, mc)
 }
@@ -163,7 +163,7 @@ fn get_any_address(
     local_addr: SocketAddr,
     timeout: Option<Duration>,
     handle: &Handle,
-    mc: &Mc,
+    mc: &P2p,
 ) -> BoxFuture<SocketAddr, GetAnyAddressError> {
     if !mc.is_igd_enabled() {
         return future::err(GetAnyAddressError::Disabled).into_boxed();

--- a/src/igd_async.rs
+++ b/src/igd_async.rs
@@ -138,12 +138,13 @@ pub fn get_any_address_rendezvous(
     local_addr: SocketAddr,
     timeout: Duration,
     handle: &Handle,
+    mc: &Mc,
 ) -> BoxFuture<SocketAddr, GetAnyAddressError> {
-    if !is_igd_enabled_for_rendezvous() {
+    if !mc.is_igd_enabled_for_rendezvous() {
         return future::err(GetAnyAddressError::Disabled).into_boxed();
     }
 
-    get_any_address(protocol, local_addr, Some(timeout), handle)
+    get_any_address(protocol, local_addr, Some(timeout), handle, mc)
 }
 
 /// Used by the `open_addr` module. This function will try to permanently open port for a server to
@@ -152,8 +153,9 @@ pub fn get_any_address_open(
     protocol: Protocol,
     local_addr: SocketAddr,
     handle: &Handle,
+    mc: &Mc,
 ) -> BoxFuture<SocketAddr, GetAnyAddressError> {
-    get_any_address(protocol, local_addr, None, handle)
+    get_any_address(protocol, local_addr, None, handle, mc)
 }
 
 fn get_any_address(
@@ -161,8 +163,9 @@ fn get_any_address(
     local_addr: SocketAddr,
     timeout: Option<Duration>,
     handle: &Handle,
+    mc: &Mc,
 ) -> BoxFuture<SocketAddr, GetAnyAddressError> {
-    if !is_igd_enabled() {
+    if !mc.is_igd_enabled() {
         return future::err(GetAnyAddressError::Disabled).into_boxed();
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -186,8 +186,6 @@
 //!
 //! [0]: https://en.wikipedia.org/wiki/Internet_Gateway_Device_Protocol
 
-#[macro_use]
-extern crate lazy_static;
 extern crate tokio_io;
 extern crate tokio_core;
 extern crate futures;

--- a/src/mc.rs
+++ b/src/mc.rs
@@ -51,11 +51,11 @@ impl P2p {
         !inner_get!(self, igd_disabled_for_rendezvous)
     }
 
-    pub fn enable_igd_for_rendezvous(&mut self) {
+    pub fn enable_igd_for_rendezvous(&self) {
         inner_set!(self, igd_disabled_for_rendezvous, false);
     }
 
-    pub fn disable_igd_for_rendezvous(&mut self) {
+    pub fn disable_igd_for_rendezvous(&self) {
         inner_set!(self, igd_disabled_for_rendezvous, true);
     }
 
@@ -71,61 +71,61 @@ impl P2p {
 
     /// By default `p2p` attempts to use IGD to open external ports for it's own use.
     /// Use this function to disable such behaviour.
-    pub fn disable_igd(&mut self) {
+    pub fn disable_igd(&self) {
         inner_set!(self, igd_disabled, true);
     }
 
     /// Re-enables IGD use.
-    pub fn enable_igd(&mut self) {
+    pub fn enable_igd(&self) {
         inner_set!(self, igd_disabled, false);
     }
 
     /// Tell about a `TcpTraversalServer` than can be used to help use perform rendezvous
     /// connects and hole punching.
-    pub fn add_tcp_traversal_server(&mut self, addr: &SocketAddr) {
+    pub fn add_tcp_traversal_server(&self, addr: &SocketAddr) {
         self.add_server(Protocol::Tcp, addr);
     }
 
     /// Tells the library to forget a `TcpTraversalServer` previously added with
     /// `add_tcp_traversal_server`.
-    pub fn remove_tcp_traversal_server(&mut self, addr: &SocketAddr) {
+    pub fn remove_tcp_traversal_server(&self, addr: &SocketAddr) {
         self.remove_server(Protocol::Tcp, addr);
     }
 
     /// Returns a iterator over all tcp traversal server addresses.
-    pub fn tcp_traversal_servers(&mut self) -> Servers {
+    pub fn tcp_traversal_servers(&self) -> Servers {
         self.iter_servers(Protocol::Tcp)
     }
 
     /// Tell about a `UdpTraversalServer` than can be used to help use perform rendezvous
     /// connects and hole punching.
-    pub fn add_udp_traversal_server(&mut self, addr: &SocketAddr) {
+    pub fn add_udp_traversal_server(&self, addr: &SocketAddr) {
         self.add_server(Protocol::Udp, addr);
     }
 
     /// Tells the library to forget a `UdpTraversalServer` previously added with
     /// `add_udp_traversal_server`.
-    pub fn remove_udp_traversal_server(&mut self, addr: &SocketAddr) {
+    pub fn remove_udp_traversal_server(&self, addr: &SocketAddr) {
         self.remove_server(Protocol::Udp, addr);
     }
 
     /// Returns an iterator over all udp traversal server addresses added with
     /// `add_tcp_traversal_server`.
-    pub fn udp_traversal_servers(&mut self) -> Servers {
+    pub fn udp_traversal_servers(&self) -> Servers {
         self.iter_servers(Protocol::Udp)
     }
 
-    pub fn iter_servers(&mut self, protocol: Protocol) -> Servers {
+    pub fn iter_servers(&self, protocol: Protocol) -> Servers {
         let mut inner = unwrap!(self.inner.lock());
         inner.server_set(protocol).iter_servers()
     }
 
-    fn add_server(&mut self, protocol: Protocol, addr: &SocketAddr) {
+    fn add_server(&self, protocol: Protocol, addr: &SocketAddr) {
         let mut inner = unwrap!(self.inner.lock());
         inner.server_set(protocol).add_server(addr);
     }
 
-    fn remove_server(&mut self, protocol: Protocol, addr: &SocketAddr) {
+    fn remove_server(&self, protocol: Protocol, addr: &SocketAddr) {
         let mut inner = unwrap!(self.inner.lock());
         inner.server_set(protocol).remove_server(addr);
     }
@@ -300,7 +300,7 @@ mod tests {
 
             #[test]
             fn it_returns_current_tcp_traversal_servers() {
-                let mut p2p = P2p::default();
+                let p2p = P2p::default();
 
                 p2p.add_tcp_traversal_server(&addr!("1.2.3.4:4000"));
                 p2p.add_tcp_traversal_server(&addr!("1.2.3.5:5000"));
@@ -316,7 +316,7 @@ mod tests {
 
             #[test]
             fn it_removes_given_server_from_the_list_if_it_exists() {
-                let mut p2p = P2p::default();
+                let p2p = P2p::default();
                 p2p.add_tcp_traversal_server(&addr!("1.2.3.4:4000"));
                 p2p.add_tcp_traversal_server(&addr!("1.2.3.5:5000"));
 
@@ -329,7 +329,7 @@ mod tests {
 
             #[test]
             fn it_does_nothing_if_give_address_is_not_in_the_list() {
-                let mut p2p = P2p::default();
+                let p2p = P2p::default();
                 p2p.add_tcp_traversal_server(&addr!("1.2.3.5:5000"));
 
                 p2p.remove_tcp_traversal_server(&addr!("1.2.3.4:4000"));

--- a/src/mc.rs
+++ b/src/mc.rs
@@ -13,7 +13,7 @@ use tokio_io;
 ///
 /// You can edit rendezvous (traversal) servers, enable/Disable IGD use, etc.
 #[derive(Default, Clone)]
-pub struct Mc {
+pub struct P2p {
     inner: Arc<Mutex<P2pInner>>,
 }
 
@@ -46,7 +46,7 @@ macro_rules! inner_set {
     };
 }
 
-impl Mc {
+impl P2p {
     pub fn is_igd_enabled_for_rendezvous(&self) -> bool {
         !inner_get!(self, igd_disabled_for_rendezvous)
     }
@@ -275,21 +275,21 @@ mod tests {
 
             #[test]
             fn it_creates_mapping_context_with_igd_enabled() {
-                let p2p = Mc::default();
+                let p2p = P2p::default();
 
                 assert!(p2p.is_igd_enabled())
             }
 
             #[test]
             fn it_creates_mapping_context_with_igd_enabled_for_rendezvous() {
-                let p2p = Mc::default();
+                let p2p = P2p::default();
 
                 assert!(p2p.is_igd_enabled_for_rendezvous())
             }
 
             #[test]
             fn it_creates_mapping_context_with_force_use_local_port_disabled() {
-                let p2p = Mc::default();
+                let p2p = P2p::default();
 
                 assert!(!p2p.force_use_local_port())
             }
@@ -300,7 +300,7 @@ mod tests {
 
             #[test]
             fn it_returns_current_tcp_traversal_servers() {
-                let mut p2p = Mc::default();
+                let mut p2p = P2p::default();
 
                 p2p.add_tcp_traversal_server(&addr!("1.2.3.4:4000"));
                 p2p.add_tcp_traversal_server(&addr!("1.2.3.5:5000"));
@@ -316,7 +316,7 @@ mod tests {
 
             #[test]
             fn it_removes_given_server_from_the_list_if_it_exists() {
-                let mut p2p = Mc::default();
+                let mut p2p = P2p::default();
                 p2p.add_tcp_traversal_server(&addr!("1.2.3.4:4000"));
                 p2p.add_tcp_traversal_server(&addr!("1.2.3.5:5000"));
 
@@ -329,7 +329,7 @@ mod tests {
 
             #[test]
             fn it_does_nothing_if_give_address_is_not_in_the_list() {
-                let mut p2p = Mc::default();
+                let mut p2p = P2p::default();
                 p2p.add_tcp_traversal_server(&addr!("1.2.3.5:5000"));
 
                 p2p.remove_tcp_traversal_server(&addr!("1.2.3.4:4000"));

--- a/src/mc.rs
+++ b/src/mc.rs
@@ -9,13 +9,9 @@ use protocol::Protocol;
 use server_set::{ServerSet, Servers};
 use tokio_io;
 
-lazy_static! {
-    static ref MC: Mutex<Mc> = Mutex::new(Mc::default());
-}
-
 /// `Mc` stands for `MappingContext` and is related to port mapping.
-#[derive(Default)]
-struct Mc {
+#[derive(Default, Clone)]
+pub struct Mc {
     tcp_server_set: ServerSet,
     udp_server_set: ServerSet,
     igd_disabled: bool,
@@ -24,71 +20,93 @@ struct Mc {
 }
 
 impl Mc {
-    fn server_set(&mut self, protocol: Protocol) -> &mut ServerSet {
+    pub fn is_igd_enabled_for_rendezvous(&self) -> bool {
+        !self.igd_disabled_for_rendezvous
+    }
+
+    pub fn force_use_local_port(&self) -> bool {
+        self.force_use_local_port
+    }
+
+    /// Tests if IGD use is enabled or not.
+    /// It's enabled by default.
+    pub fn is_igd_enabled(&self) -> bool {
+        !self.igd_disabled
+    }
+
+    pub fn enable_igd_for_rendezvous(&mut self) {
+        self.igd_disabled_for_rendezvous = false;
+    }
+
+    pub fn server_set(&mut self, protocol: Protocol) -> &mut ServerSet {
         match protocol {
             Protocol::Udp => &mut self.udp_server_set,
             Protocol::Tcp => &mut self.tcp_server_set,
         }
     }
 
-    fn add_server(&mut self, protocol: Protocol, addr: &SocketAddr) {
+    /// Tell about a `TcpTraversalServer` than can be used to help use perform rendezvous
+    /// connects and hole punching.
+    pub fn add_server(&mut self, protocol: Protocol, addr: &SocketAddr) {
         self.server_set(protocol).add_server(addr)
     }
 
-    fn remove_server(&mut self, protocol: Protocol, addr: &SocketAddr) {
+    /// Tells to forget a `TcpTraversalServer` previously added with `add_server`.
+    pub fn remove_server(&mut self, protocol: Protocol, addr: &SocketAddr) {
         self.server_set(protocol).remove_server(addr)
     }
 
-    fn iter_servers(&mut self, protocol: Protocol) -> Servers {
+    pub fn iter_servers(&mut self, protocol: Protocol) -> Servers {
         self.server_set(protocol).iter_servers()
     }
-}
 
-/// Tell the library about a `TcpTraversalServer` than can be used to help use perform rendezvous
-/// connects and hole punching.
-pub fn add_tcp_traversal_server(addr: &SocketAddr) {
-    let mut mc = unwrap!(MC.lock());
-    mc.add_server(Protocol::Tcp, addr)
-}
+    /// Returns an iterator over all tcp traversal server addresses added with `add_server`.
+    pub fn tcp_traversal_servers(&mut self) -> Servers {
+        self.iter_servers(Protocol::Tcp)
+    }
 
-/// Tells the library to forget a `TcpTraversalServer` previously added with
-/// `add_tcp_traversal_server`.
-pub fn remove_tcp_traversal_server(addr: &SocketAddr) {
-    let mut mc = unwrap!(MC.lock());
-    mc.remove_server(Protocol::Tcp, addr)
-}
+    /// Tell about a `TcpTraversalServer` than can be used to help use perform rendezvous
+    /// connects and hole punching.
+    pub fn add_tcp_traversal_server(&mut self, addr: &SocketAddr) {
+        self.add_server(Protocol::Tcp, addr)
+    }
 
-/// Returns an iterator over all tcp traversal server addresses added with
-/// `add_tcp_traversal_server`.
-pub fn tcp_traversal_servers() -> Servers {
-    let mut mc = unwrap!(MC.lock());
-    mc.iter_servers(Protocol::Tcp)
-}
+    /// Tell about a `UdpTraversalServer` than can be used to help use perform rendezvous
+    /// connects and hole punching.
+    pub fn add_udp_traversal_server(&mut self, addr: &SocketAddr) {
+        self.add_server(Protocol::Udp, addr)
+    }
 
-/// Tell the library about a `UdpTraversalServer` than can be used to help use perform rendezvous
-/// connects and hole punching.
-pub fn add_udp_traversal_server(addr: &SocketAddr) {
-    let mut mc = unwrap!(MC.lock());
-    mc.add_server(Protocol::Udp, addr)
-}
+    /// Tells the library to forget a `UdpTraversalServer` previously added with
+    /// `add_udp_traversal_server`.
+    pub fn remove_udp_traversal_server(&mut self, addr: &SocketAddr) {
+        self.remove_server(Protocol::Udp, addr)
+    }
 
-/// Tells the library to forget a `UdpTraversalServer` previously added with
-/// `add_udp_traversal_server`.
-pub fn remove_udp_traversal_server(addr: &SocketAddr) {
-    let mut mc = unwrap!(MC.lock());
-    mc.remove_server(Protocol::Udp, addr)
-}
+    /// Returns an iterator over all udp traversal server addresses added with
+    /// `add_tcp_traversal_server`.
+    pub fn udp_traversal_servers(&mut self) -> Servers {
+        self.iter_servers(Protocol::Udp)
+    }
 
-/// Returns an iterator over all udp traversal server addresses added with
-/// `add_tcp_traversal_server`.
-pub fn udp_traversal_servers() -> Servers {
-    let mut mc = unwrap!(MC.lock());
-    mc.iter_servers(Protocol::Udp)
-}
+    /// By default `p2p` attempts to use IGD to open external ports for it's own use.
+    /// Use this function to disable such behaviour.
+    pub fn disable_igd(&mut self) {
+        self.igd_disabled = true;
+    }
 
-pub fn traversal_servers(protocol: Protocol) -> Servers {
-    let mut mc = unwrap!(MC.lock());
-    mc.iter_servers(protocol)
+    /// Re-enables IGD use.
+    pub fn enable_igd(&mut self) {
+        self.igd_disabled = false;
+    }
+
+    pub fn disable_igd_for_rendezvous(&mut self) {
+        self.igd_disabled_for_rendezvous = true;
+    }
+
+    pub fn set_force_use_local_port(&mut self, force: bool) {
+        self.force_use_local_port = force;
+    }
 }
 
 pub fn query_public_addr(
@@ -101,31 +119,6 @@ pub fn query_public_addr(
         Protocol::Tcp => tcp_query_public_addr(bind_addr, server_addr, handle),
         Protocol::Udp => udp_query_public_addr(bind_addr, server_addr, handle),
     }
-}
-
-pub fn enable_igd_for_rendezvous() {
-    let mut mc = unwrap!(MC.lock());
-    mc.igd_disabled_for_rendezvous = false;
-}
-
-pub fn disable_igd_for_rendezvous() {
-    let mut mc = unwrap!(MC.lock());
-    mc.igd_disabled_for_rendezvous = true;
-}
-
-pub fn is_igd_enabled_for_rendezvous() -> bool {
-    let mc = unwrap!(MC.lock());
-    !mc.igd_disabled_for_rendezvous
-}
-
-pub fn force_use_local_port() -> bool {
-    let mc = unwrap!(MC.lock());
-    mc.force_use_local_port
-}
-
-pub fn set_force_use_local_port(force: bool) {
-    let mut mc = unwrap!(MC.lock());
-    mc.force_use_local_port = force;
 }
 
 quick_error! {
@@ -237,25 +230,4 @@ pub fn udp_query_public_addr(
         })
     };
     future::result(try()).flatten().into_boxed()
-}
-
-/// Tests if IGD use is enabled or not.
-/// It's enabled by default.
-pub fn is_igd_enabled() -> bool {
-    let mc = unwrap!(MC.lock());
-    !mc.igd_disabled
-}
-
-/// By default `p2p` attempts to use IGD to open external ports for it's own use.
-/// Use this function to disable such behaviour. It set's a singleton flag value hence
-/// disables IGD for a whole `p2p` crate.
-pub fn disable_igd() {
-    let mut mc = unwrap!(MC.lock());
-    mc.igd_disabled = true;
-}
-
-/// Re-enables IGD use in `p2p` crate.
-pub fn enable_igd() {
-    let mut mc = unwrap!(MC.lock());
-    mc.igd_disabled = false;
 }

--- a/src/open_addr.rs
+++ b/src/open_addr.rs
@@ -74,6 +74,7 @@ pub fn open_addr(
     protocol: Protocol,
     bind_addr: &SocketAddr,
     handle: &Handle,
+    mc: &Mc,
 ) -> BoxFuture<SocketAddr, OpenAddrError> {
     let addrs_res = {
         bind_addr.expand_local_unspecified().map_err(|e| {
@@ -100,7 +101,8 @@ pub fn open_addr(
     let bind_addr = *bind_addr;
     let handle = handle.clone();
 
-    igd_async::get_any_address_open(protocol, bind_addr, &handle)
+    let mut mc0 = mc.clone();
+    igd_async::get_any_address_open(protocol, bind_addr, &handle, mc)
         .or_else(move |igd_err| {
             OpenAddr {
                 protocol: protocol,
@@ -108,7 +110,7 @@ pub fn open_addr(
                 handle: handle,
                 bind_addr: bind_addr,
                 known_addr_opt: None,
-                traversal_servers: mc::traversal_servers(protocol),
+                traversal_servers: mc0.iter_servers(protocol),
                 active_queries: stream::FuturesUnordered::new(),
                 errors: Vec::new(),
                 more_servers_timeout: None,

--- a/src/open_addr.rs
+++ b/src/open_addr.rs
@@ -74,7 +74,7 @@ pub fn open_addr(
     protocol: Protocol,
     bind_addr: &SocketAddr,
     handle: &Handle,
-    mc: &Mc,
+    mc: &P2p,
 ) -> BoxFuture<SocketAddr, OpenAddrError> {
     let addrs_res = {
         bind_addr.expand_local_unspecified().map_err(|e| {

--- a/src/open_addr.rs
+++ b/src/open_addr.rs
@@ -101,7 +101,7 @@ pub fn open_addr(
     let bind_addr = *bind_addr;
     let handle = handle.clone();
 
-    let mut mc0 = mc.clone();
+    let mc0 = mc.clone();
     igd_async::get_any_address_open(protocol, bind_addr, &handle, mc)
         .or_else(move |igd_err| {
             OpenAddr {

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -1,6 +1,6 @@
 pub use ip_addr::{IpAddrExt, Ipv4AddrExt, Ipv6AddrExt};
 
-pub use mc::Mc;
+pub use mc::P2p;
 pub use open_addr::{BindPublicError, OpenAddrError, OpenAddrErrorKind};
 pub use rendezvous_addr::{RendezvousAddrError, RendezvousAddrErrorKind};
 pub use socket_addr::{SocketAddrExt, SocketAddrV4Ext, SocketAddrV6Ext};

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -1,10 +1,6 @@
 pub use ip_addr::{IpAddrExt, Ipv4AddrExt, Ipv6AddrExt};
 
-pub use mc::{add_tcp_traversal_server, remove_tcp_traversal_server, tcp_traversal_servers};
-pub use mc::{add_udp_traversal_server, remove_udp_traversal_server, udp_traversal_servers};
-pub use mc::{disable_igd, disable_igd_for_rendezvous, enable_igd, enable_igd_for_rendezvous,
-             force_use_local_port, is_igd_enabled, is_igd_enabled_for_rendezvous,
-             set_force_use_local_port};
+pub use mc::Mc;
 pub use open_addr::{BindPublicError, OpenAddrError, OpenAddrErrorKind};
 pub use rendezvous_addr::{RendezvousAddrError, RendezvousAddrErrorKind};
 pub use socket_addr::{SocketAddrExt, SocketAddrV4Ext, SocketAddrV6Ext};

--- a/src/priv_prelude.rs
+++ b/src/priv_prelude.rs
@@ -8,7 +8,7 @@ pub use future_utils::Timeout;
 pub use futures::{Async, AsyncSink, Future, Sink, Stream, future, sink, stream};
 
 pub use log::LogLevel;
-pub use mc::QueryPublicAddrError;
+pub use mc::{Mc, QueryPublicAddrError};
 pub use net2::{TcpBuilder, UdpBuilder};
 
 pub use prelude::*;

--- a/src/priv_prelude.rs
+++ b/src/priv_prelude.rs
@@ -8,7 +8,7 @@ pub use future_utils::Timeout;
 pub use futures::{Async, AsyncSink, Future, Sink, Stream, future, sink, stream};
 
 pub use log::LogLevel;
-pub use mc::{Mc, QueryPublicAddrError};
+pub use mc::{P2p, QueryPublicAddrError};
 pub use net2::{TcpBuilder, UdpBuilder};
 
 pub use prelude::*;

--- a/src/rendezvous_addr.rs
+++ b/src/rendezvous_addr.rs
@@ -52,7 +52,7 @@ pub fn rendezvous_addr(
     protocol: Protocol,
     bind_addr: &SocketAddr,
     handle: &Handle,
-    mc: &mut P2p,
+    mc: &P2p,
 ) -> BoxFuture<SocketAddr, RendezvousAddrError> {
     let bind_addr = *bind_addr;
     let handle = handle.clone();

--- a/src/rendezvous_addr.rs
+++ b/src/rendezvous_addr.rs
@@ -52,7 +52,7 @@ pub fn rendezvous_addr(
     protocol: Protocol,
     bind_addr: &SocketAddr,
     handle: &Handle,
-    mc: &mut Mc,
+    mc: &mut P2p,
 ) -> BoxFuture<SocketAddr, RendezvousAddrError> {
     let bind_addr = *bind_addr;
     let handle = handle.clone();

--- a/src/rendezvous_addr.rs
+++ b/src/rendezvous_addr.rs
@@ -52,10 +52,11 @@ pub fn rendezvous_addr(
     protocol: Protocol,
     bind_addr: &SocketAddr,
     handle: &Handle,
+    mc: &mut Mc,
 ) -> BoxFuture<SocketAddr, RendezvousAddrError> {
     let bind_addr = *bind_addr;
     let handle = handle.clone();
-    let mut servers = mc::traversal_servers(protocol);
+    let mut servers = mc.iter_servers(protocol);
     let mut active_queries =
         stream::FuturesOrdered::<BoxFuture<SocketAddr, QueryPublicAddrError>>::new();
     let mut errors = Vec::new();
@@ -63,8 +64,10 @@ pub fn rendezvous_addr(
     let mut ports = Vec::new();
     let mut known_ip_opt = None;
     let mut failed_sequences = 0;
+    let mc0 = mc.clone();
 
-    igd_async::get_any_address_rendezvous(protocol, bind_addr, Duration::from_secs(300), &handle)
+    let timeout = Duration::from_secs(300);
+    igd_async::get_any_address_rendezvous(protocol, bind_addr, timeout, &handle, mc)
         .or_else(move |igd_error| {
             let mut igd_error = Some(igd_error);
             future::poll_fn(move || loop {
@@ -185,7 +188,7 @@ pub fn rendezvous_addr(
                         return Ok(Async::NotReady);
                     }
                 }
-            }).map(move |addr| if force_use_local_port() {
+            }).map(move |addr| if mc0.force_use_local_port() {
                 SocketAddr::new(addr.ip(), bind_addr.port())
             } else {
                 addr

--- a/src/server_set.rs
+++ b/src/server_set.rs
@@ -2,7 +2,7 @@ use future_utils::mpsc::{UnboundedReceiver, UnboundedSender, unbounded};
 use priv_prelude::*;
 use rand;
 
-#[derive(Default)]
+#[derive(Default, Clone)]
 pub struct ServerSet {
     servers: HashSet<SocketAddr>,
     iterators: Vec<UnboundedSender<(SocketAddr, bool)>>,

--- a/src/server_set.rs
+++ b/src/server_set.rs
@@ -42,6 +42,13 @@ pub struct Servers {
     modifications: UnboundedReceiver<(SocketAddr, bool)>,
 }
 
+impl Servers {
+    /// Returns a snapshot of current server list.
+    pub fn snapshot(&self) -> HashSet<SocketAddr> {
+        self.servers.clone()
+    }
+}
+
 impl Stream for Servers {
     type Item = SocketAddr;
     type Error = Void;
@@ -61,5 +68,30 @@ impl Stream for Servers {
         };
 
         Ok(Async::Ready(Some(server)))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    mod servers {
+        use super::*;
+
+        mod snapshot {
+            use super::*;
+
+            #[test]
+            fn it_returns_current_server_list() {
+                let mut servers = ServerSet::default();
+                servers.add_server(&addr!("1.2.3.4:4000"));
+                servers.add_server(&addr!("1.2.3.5:5000"));
+
+                let addrs = servers.iter_servers().snapshot();
+
+                assert!(addrs.contains(&addr!("1.2.3.4:4000")));
+                assert!(addrs.contains(&addr!("1.2.3.5:5000")));
+            }
+        }
     }
 }

--- a/src/tcp/listener.rs
+++ b/src/tcp/listener.rs
@@ -21,7 +21,7 @@ pub trait TcpListenerExt {
     fn bind_public(
         addr: &SocketAddr,
         handle: &Handle,
-        mc: &mut Mc,
+        mc: &mut P2p,
     ) -> BoxFuture<(TcpListener, SocketAddr), BindPublicError>;
 }
 
@@ -43,7 +43,7 @@ impl TcpListenerExt for TcpListener {
     fn bind_public(
         addr: &SocketAddr,
         handle: &Handle,
-        mc: &mut Mc,
+        mc: &mut P2p,
     ) -> BoxFuture<(TcpListener, SocketAddr), BindPublicError> {
         bind_public_with_addr(addr, handle, mc)
             .map(|(listener, _bind_addr, public_addr)| {
@@ -56,7 +56,7 @@ impl TcpListenerExt for TcpListener {
 pub fn bind_public_with_addr(
     addr: &SocketAddr,
     handle: &Handle,
-    mc: &Mc,
+    mc: &P2p,
 ) -> BoxFuture<(TcpListener, SocketAddr, SocketAddr), BindPublicError> {
     let handle = handle.clone();
     let try = || {

--- a/src/tcp/listener.rs
+++ b/src/tcp/listener.rs
@@ -21,7 +21,7 @@ pub trait TcpListenerExt {
     fn bind_public(
         addr: &SocketAddr,
         handle: &Handle,
-        mc: &mut P2p,
+        mc: &P2p,
     ) -> BoxFuture<(TcpListener, SocketAddr), BindPublicError>;
 }
 
@@ -43,7 +43,7 @@ impl TcpListenerExt for TcpListener {
     fn bind_public(
         addr: &SocketAddr,
         handle: &Handle,
-        mc: &mut P2p,
+        mc: &P2p,
     ) -> BoxFuture<(TcpListener, SocketAddr), BindPublicError> {
         bind_public_with_addr(addr, handle, mc)
             .map(|(listener, _bind_addr, public_addr)| {

--- a/src/tcp/listener.rs
+++ b/src/tcp/listener.rs
@@ -21,6 +21,7 @@ pub trait TcpListenerExt {
     fn bind_public(
         addr: &SocketAddr,
         handle: &Handle,
+        mc: &mut Mc,
     ) -> BoxFuture<(TcpListener, SocketAddr), BindPublicError>;
 }
 
@@ -42,8 +43,9 @@ impl TcpListenerExt for TcpListener {
     fn bind_public(
         addr: &SocketAddr,
         handle: &Handle,
+        mc: &mut Mc,
     ) -> BoxFuture<(TcpListener, SocketAddr), BindPublicError> {
-        bind_public_with_addr(addr, handle)
+        bind_public_with_addr(addr, handle, mc)
             .map(|(listener, _bind_addr, public_addr)| {
                 (listener, public_addr)
             })
@@ -54,6 +56,7 @@ impl TcpListenerExt for TcpListener {
 pub fn bind_public_with_addr(
     addr: &SocketAddr,
     handle: &Handle,
+    mc: &Mc,
 ) -> BoxFuture<(TcpListener, SocketAddr, SocketAddr), BindPublicError> {
     let handle = handle.clone();
     let try = || {
@@ -64,7 +67,7 @@ pub fn bind_public_with_addr(
             listener.local_addr().map_err(BindPublicError::Bind)
         }?;
         Ok({
-            open_addr(Protocol::Tcp, &bind_addr, &handle)
+            open_addr(Protocol::Tcp, &bind_addr, &handle, mc)
                 .map_err(BindPublicError::OpenAddr)
                 .map(move |public_addr| (listener, bind_addr, public_addr))
         })

--- a/src/tcp/rendezvous_server.rs
+++ b/src/tcp/rendezvous_server.rs
@@ -51,7 +51,7 @@ impl TcpRendezvousServer {
     pub fn bind_public(
         addr: &SocketAddr,
         handle: &Handle,
-        mc: &mut Mc,
+        mc: &mut P2p,
     ) -> BoxFuture<(TcpRendezvousServer, SocketAddr), BindPublicError> {
         let handle = handle.clone();
         listener::bind_public_with_addr(addr, &handle, mc)

--- a/src/tcp/rendezvous_server.rs
+++ b/src/tcp/rendezvous_server.rs
@@ -51,7 +51,7 @@ impl TcpRendezvousServer {
     pub fn bind_public(
         addr: &SocketAddr,
         handle: &Handle,
-        mc: &mut P2p,
+        mc: &P2p,
     ) -> BoxFuture<(TcpRendezvousServer, SocketAddr), BindPublicError> {
         let handle = handle.clone();
         listener::bind_public_with_addr(addr, &handle, mc)

--- a/src/tcp/rendezvous_server.rs
+++ b/src/tcp/rendezvous_server.rs
@@ -51,9 +51,10 @@ impl TcpRendezvousServer {
     pub fn bind_public(
         addr: &SocketAddr,
         handle: &Handle,
+        mc: &mut Mc,
     ) -> BoxFuture<(TcpRendezvousServer, SocketAddr), BindPublicError> {
         let handle = handle.clone();
-        listener::bind_public_with_addr(addr, &handle)
+        listener::bind_public_with_addr(addr, &handle, mc)
             .map(move |(listener, bind_addr, public_addr)| {
                 (
                     from_listener_inner(listener, &bind_addr, &handle),

--- a/src/tcp/stream.rs
+++ b/src/tcp/stream.rs
@@ -157,7 +157,7 @@ pub trait TcpStreamExt {
     /// to form one TCP connection, connected from both ends. `channel` must provide a channel
     /// through which the two connecting peers can communicate with each other out-of-band while
     /// negotiating the connection.
-    fn rendezvous_connect<C>(channel: C, handle: &Handle, mc: &mut Mc) -> TcpRendezvousConnect<C>
+    fn rendezvous_connect<C>(channel: C, handle: &Handle, mc: &mut P2p) -> TcpRendezvousConnect<C>
     where
         C: Stream<Item = Bytes>,
         C: Sink<SinkItem = Bytes>,
@@ -189,7 +189,7 @@ impl TcpStreamExt for TcpStream {
         future::result(try()).flatten().into_boxed()
     }
 
-    fn rendezvous_connect<C>(channel: C, handle: &Handle, mc: &mut Mc) -> TcpRendezvousConnect<C>
+    fn rendezvous_connect<C>(channel: C, handle: &Handle, mc: &mut P2p) -> TcpRendezvousConnect<C>
     where
         C: Stream<Item = Bytes>,
         C: Sink<SinkItem = Bytes>,
@@ -376,7 +376,7 @@ mod test {
 
         let mut core = unwrap!(Core::new());
         let handle = core.handle();
-        let mut mc0 = Mc::default();
+        let mut mc0 = P2p::default();
         let mut mc1 = mc0.clone();
 
         let result = core.run({

--- a/src/tcp/stream.rs
+++ b/src/tcp/stream.rs
@@ -157,7 +157,7 @@ pub trait TcpStreamExt {
     /// to form one TCP connection, connected from both ends. `channel` must provide a channel
     /// through which the two connecting peers can communicate with each other out-of-band while
     /// negotiating the connection.
-    fn rendezvous_connect<C>(channel: C, handle: &Handle, mc: &mut P2p) -> TcpRendezvousConnect<C>
+    fn rendezvous_connect<C>(channel: C, handle: &Handle, mc: &P2p) -> TcpRendezvousConnect<C>
     where
         C: Stream<Item = Bytes>,
         C: Sink<SinkItem = Bytes>,
@@ -189,7 +189,7 @@ impl TcpStreamExt for TcpStream {
         future::result(try()).flatten().into_boxed()
     }
 
-    fn rendezvous_connect<C>(channel: C, handle: &Handle, mc: &mut P2p) -> TcpRendezvousConnect<C>
+    fn rendezvous_connect<C>(channel: C, handle: &Handle, mc: &P2p) -> TcpRendezvousConnect<C>
     where
         C: Stream<Item = Bytes>,
         C: Sink<SinkItem = Bytes>,
@@ -376,12 +376,12 @@ mod test {
 
         let mut core = unwrap!(Core::new());
         let handle = core.handle();
-        let mut mc0 = P2p::default();
-        let mut mc1 = mc0.clone();
+        let mc0 = P2p::default();
+        let mc1 = mc0.clone();
 
         let result = core.run({
             let f0 = {
-                TcpStream::rendezvous_connect(ch0, &handle, &mut mc0)
+                TcpStream::rendezvous_connect(ch0, &handle, &mc0)
                     .map_err(|e| panic!("connect failed: {:?}", e))
                     .and_then(|stream| tokio_io::io::write_all(stream, b"hello"))
                     .map_err(|e| panic!("writing failed: {:?}", e))
@@ -389,7 +389,7 @@ mod test {
             };
 
             let f1 = {
-                TcpStream::rendezvous_connect(ch1, &handle, &mut mc1)
+                TcpStream::rendezvous_connect(ch1, &handle, &mc1)
                     .map_err(|e| panic!("connect failed: {:?}", e))
                     .and_then(|stream| tokio_io::io::read_to_end(stream, Vec::new()))
                     .map_err(|e| panic!("reading failed: {:?}", e))

--- a/src/tcp/stream.rs
+++ b/src/tcp/stream.rs
@@ -157,7 +157,7 @@ pub trait TcpStreamExt {
     /// to form one TCP connection, connected from both ends. `channel` must provide a channel
     /// through which the two connecting peers can communicate with each other out-of-band while
     /// negotiating the connection.
-    fn rendezvous_connect<C>(channel: C, handle: &Handle) -> TcpRendezvousConnect<C>
+    fn rendezvous_connect<C>(channel: C, handle: &Handle, mc: &mut Mc) -> TcpRendezvousConnect<C>
     where
         C: Stream<Item = Bytes>,
         C: Sink<SinkItem = Bytes>,
@@ -189,7 +189,7 @@ impl TcpStreamExt for TcpStream {
         future::result(try()).flatten().into_boxed()
     }
 
-    fn rendezvous_connect<C>(channel: C, handle: &Handle) -> TcpRendezvousConnect<C>
+    fn rendezvous_connect<C>(channel: C, handle: &Handle, mc: &mut Mc) -> TcpRendezvousConnect<C>
     where
         C: Stream<Item = Bytes>,
         C: Sink<SinkItem = Bytes>,
@@ -225,7 +225,7 @@ impl TcpStreamExt for TcpStream {
 
             Ok({
                 trace!("getting rendezvous address");
-                rendezvous_addr(Protocol::Tcp, &bind_addr, &handle)
+                rendezvous_addr(Protocol::Tcp, &bind_addr, &handle, mc)
                     .then(|res| match res {
                         Ok(addr) => Ok((Some(addr), None)),
                         Err(e) => Ok((None, Some(e))),
@@ -376,10 +376,12 @@ mod test {
 
         let mut core = unwrap!(Core::new());
         let handle = core.handle();
+        let mut mc0 = Mc::default();
+        let mut mc1 = mc0.clone();
 
         let result = core.run({
             let f0 = {
-                TcpStream::rendezvous_connect(ch0, &handle)
+                TcpStream::rendezvous_connect(ch0, &handle, &mut mc0)
                     .map_err(|e| panic!("connect failed: {:?}", e))
                     .and_then(|stream| tokio_io::io::write_all(stream, b"hello"))
                     .map_err(|e| panic!("writing failed: {:?}", e))
@@ -387,7 +389,7 @@ mod test {
             };
 
             let f1 = {
-                TcpStream::rendezvous_connect(ch1, &handle)
+                TcpStream::rendezvous_connect(ch1, &handle, &mut mc1)
                     .map_err(|e| panic!("connect failed: {:?}", e))
                     .and_then(|stream| tokio_io::io::read_to_end(stream, Vec::new()))
                     .map_err(|e| panic!("reading failed: {:?}", e))

--- a/src/udp/rendezvous_server.rs
+++ b/src/udp/rendezvous_server.rs
@@ -34,7 +34,7 @@ impl UdpRendezvousServer {
     pub fn bind_public(
         addr: &SocketAddr,
         handle: &Handle,
-        mc: &mut P2p,
+        mc: &P2p,
     ) -> BoxFuture<(UdpRendezvousServer, SocketAddr), BindPublicError> {
         let handle = handle.clone();
         socket::bind_public_with_addr(addr, &handle, mc)

--- a/src/udp/rendezvous_server.rs
+++ b/src/udp/rendezvous_server.rs
@@ -34,9 +34,10 @@ impl UdpRendezvousServer {
     pub fn bind_public(
         addr: &SocketAddr,
         handle: &Handle,
+        mc: &mut Mc,
     ) -> BoxFuture<(UdpRendezvousServer, SocketAddr), BindPublicError> {
         let handle = handle.clone();
-        socket::bind_public_with_addr(addr, &handle)
+        socket::bind_public_with_addr(addr, &handle, mc)
             .map(move |(socket, bind_addr, public_addr)| {
                 (from_socket_inner(socket, &bind_addr, &handle), public_addr)
             })

--- a/src/udp/rendezvous_server.rs
+++ b/src/udp/rendezvous_server.rs
@@ -34,7 +34,7 @@ impl UdpRendezvousServer {
     pub fn bind_public(
         addr: &SocketAddr,
         handle: &Handle,
-        mc: &mut Mc,
+        mc: &mut P2p,
     ) -> BoxFuture<(UdpRendezvousServer, SocketAddr), BindPublicError> {
         let handle = handle.clone();
         socket::bind_public_with_addr(addr, &handle, mc)

--- a/src/udp/socket.rs
+++ b/src/udp/socket.rs
@@ -122,7 +122,7 @@ pub trait UdpSocketExt {
     fn bind_public(
         addr: &SocketAddr,
         handle: &Handle,
-        mc: &mut Mc,
+        mc: &mut P2p,
     ) -> BoxFuture<(UdpSocket, SocketAddr), BindPublicError>;
 
     /// Perform a UDP rendezvous connection to another peer. Both peers must call this
@@ -131,7 +131,7 @@ pub trait UdpSocketExt {
     fn rendezvous_connect<C>(
         channel: C,
         handle: &Handle,
-        mc: &mut Mc,
+        mc: &mut P2p,
     ) -> BoxFuture<(UdpSocket, SocketAddr), UdpRendezvousConnectError<C::Error, C::SinkError>>
     where
         C: Stream<Item = Bytes>,
@@ -170,7 +170,7 @@ impl UdpSocketExt for UdpSocket {
     fn bind_public(
         addr: &SocketAddr,
         handle: &Handle,
-        mc: &mut Mc,
+        mc: &mut P2p,
     ) -> BoxFuture<(UdpSocket, SocketAddr), BindPublicError> {
         bind_public_with_addr(addr, handle, mc)
             .map(|(socket, _bind_addr, public_addr)| (socket, public_addr))
@@ -181,7 +181,7 @@ impl UdpSocketExt for UdpSocket {
     fn rendezvous_connect<C>(
         channel: C,
         handle: &Handle,
-        mc: &mut Mc,
+        mc: &mut P2p,
     ) -> BoxFuture<(UdpSocket, SocketAddr), UdpRendezvousConnectError<C::Error, C::SinkError>>
     where
         C: Stream<Item = Bytes>,
@@ -432,7 +432,7 @@ impl UdpSocketExt for UdpSocket {
 pub fn bind_public_with_addr(
     addr: &SocketAddr,
     handle: &Handle,
-    mc: &Mc,
+    mc: &P2p,
 ) -> BoxFuture<(UdpSocket, SocketAddr, SocketAddr), BindPublicError> {
     let handle = handle.clone();
     let try = || {
@@ -987,7 +987,7 @@ mod test {
 
         let mut core = unwrap!(Core::new());
         let handle = core.handle();
-        let mut mc0 = Mc::default();
+        let mut mc0 = P2p::default();
         let mut mc1 = mc0.clone();
 
         let result = core.run({

--- a/src/udp/socket.rs
+++ b/src/udp/socket.rs
@@ -122,6 +122,7 @@ pub trait UdpSocketExt {
     fn bind_public(
         addr: &SocketAddr,
         handle: &Handle,
+        mc: &mut Mc,
     ) -> BoxFuture<(UdpSocket, SocketAddr), BindPublicError>;
 
     /// Perform a UDP rendezvous connection to another peer. Both peers must call this
@@ -130,6 +131,7 @@ pub trait UdpSocketExt {
     fn rendezvous_connect<C>(
         channel: C,
         handle: &Handle,
+        mc: &mut Mc,
     ) -> BoxFuture<(UdpSocket, SocketAddr), UdpRendezvousConnectError<C::Error, C::SinkError>>
     where
         C: Stream<Item = Bytes>,
@@ -168,15 +170,18 @@ impl UdpSocketExt for UdpSocket {
     fn bind_public(
         addr: &SocketAddr,
         handle: &Handle,
+        mc: &mut Mc,
     ) -> BoxFuture<(UdpSocket, SocketAddr), BindPublicError> {
-        bind_public_with_addr(addr, handle)
+        bind_public_with_addr(addr, handle, mc)
             .map(|(socket, _bind_addr, public_addr)| (socket, public_addr))
             .into_boxed()
     }
 
+    // TODO(povilas): decompose this method - it would be more readable, maintainable and testable
     fn rendezvous_connect<C>(
         channel: C,
         handle: &Handle,
+        mc: &mut Mc,
     ) -> BoxFuture<(UdpSocket, SocketAddr), UdpRendezvousConnectError<C::Error, C::SinkError>>
     where
         C: Stream<Item = Bytes>,
@@ -187,10 +192,11 @@ impl UdpSocketExt for UdpSocket {
     {
         let handle0 = handle.clone();
         let handle1 = handle.clone();
+        let mc0 = mc.clone();
         let (our_pk, _sk) = crypto::box_::gen_keypair();
 
         trace!("starting rendezvous connect");
-        UdpSocket::bind_public(&addr!("0.0.0.0:0"), handle)
+        UdpSocket::bind_public(&addr!("0.0.0.0:0"), handle, mc)
             .then(move |res| match res {
                 Ok((socket, public_addr)) => {
                     let try = || {
@@ -249,6 +255,7 @@ impl UdpSocketExt for UdpSocket {
 
                         Ok({
                             let handle2 = handle0.clone();
+                            let mut mc = mc0.clone();
                             future::loop_fn(Vec::new(), move |mut sockets| {
                                 if sockets.len() == 6 {
                                     return future::ok(Loop::Break((sockets, None))).into_boxed();
@@ -268,29 +275,32 @@ impl UdpSocketExt for UdpSocket {
                                         UdpRendezvousConnectError::SetTtl,
                                     )?;
                                     Ok({
-                                        rendezvous_addr(Protocol::Udp, &bind_addr, &handle0).then(
-                                            move |res| match res {
-                                                Ok(addr) => {
-                                                    sockets.push((socket, addr));
-                                                    trace!(
-                                                        "generated {} rendezvous sockets",
-                                                        sockets.len()
-                                                    );
-                                                    Ok(Loop::Continue(sockets))
-                                                }
-                                                Err(err) => {
-                                                    trace!(
-                                                        "error generating rendezvous socket: {}",
-                                                        err
-                                                    );
-                                                    trace!(
-                                                        "stopping after generating {} sockets",
-                                                        sockets.len()
-                                                    );
-                                                    Ok(Loop::Break((sockets, Some(err))))
-                                                }
-                                            },
-                                        )
+                                        rendezvous_addr(
+                                            Protocol::Udp,
+                                            &bind_addr,
+                                            &handle0,
+                                            &mut mc,
+                                        ).then(move |res| match res {
+                                            Ok(addr) => {
+                                                sockets.push((socket, addr));
+                                                trace!(
+                                                    "generated {} rendezvous sockets",
+                                                    sockets.len()
+                                                );
+                                                Ok(Loop::Continue(sockets))
+                                            }
+                                            Err(err) => {
+                                                trace!(
+                                                    "error generating rendezvous socket: {}",
+                                                    err
+                                                );
+                                                trace!(
+                                                    "stopping after generating {} sockets",
+                                                    sockets.len()
+                                                );
+                                                Ok(Loop::Break((sockets, Some(err))))
+                                            }
+                                        })
                                     })
                                 };
                                 future::result(try()).flatten().into_boxed()
@@ -422,6 +432,7 @@ impl UdpSocketExt for UdpSocket {
 pub fn bind_public_with_addr(
     addr: &SocketAddr,
     handle: &Handle,
+    mc: &Mc,
 ) -> BoxFuture<(UdpSocket, SocketAddr, SocketAddr), BindPublicError> {
     let handle = handle.clone();
     let try = || {
@@ -432,7 +443,7 @@ pub fn bind_public_with_addr(
             socket.local_addr().map_err(BindPublicError::Bind)
         }?;
         Ok({
-            open_addr(Protocol::Udp, &bind_addr, &handle)
+            open_addr(Protocol::Udp, &bind_addr, &handle, mc)
                 .map_err(BindPublicError::OpenAddr)
                 .map(move |public_addr| (socket, bind_addr, public_addr))
         })
@@ -976,10 +987,12 @@ mod test {
 
         let mut core = unwrap!(Core::new());
         let handle = core.handle();
+        let mut mc0 = Mc::default();
+        let mut mc1 = mc0.clone();
 
         let result = core.run({
             let f0 = {
-                UdpSocket::rendezvous_connect(ch0, &handle)
+                UdpSocket::rendezvous_connect(ch0, &handle, &mut mc0)
                     .map_err(|e| panic!("connect failed: {:?}", e))
                     .and_then(|(socket, addr)| {
                         trace!("rendezvous connect successful! connected to {}", addr);
@@ -990,7 +1003,7 @@ mod test {
                     .map(|_| ())
             };
             let f1 = {
-                UdpSocket::rendezvous_connect(ch1, &handle)
+                UdpSocket::rendezvous_connect(ch1, &handle, &mut mc1)
                 .map_err(|e| panic!("connect failed: {:?}", e))
                 .and_then(|(socket, addr)| {
                     trace!("rendezvous connect successful! connected to {}", addr);


### PR DESCRIPTION
Use mapping context instance variable instead of singleton object.