### PR TITLE
Increase rendezvous connection info exchange timeouts

### DIFF
--- a/src/tcp/stream.rs
+++ b/src/tcp/stream.rs
@@ -9,6 +9,7 @@ use tcp::msg::TcpRendezvousMsg;
 use tokio_io;
 
 const RENDEZVOUS_TIMEOUT_SEC: u64 = 10;
+const RENDEZVOUS_INFO_EXCHANGE_TIMEOUT_SEC: u64 = 120;
 
 quick_error! {
     /// Errors returned by `TcpStreamExt::connect_reusable`.
@@ -251,7 +252,10 @@ impl TcpStreamExt for TcpStream {
                         channel
                         .map_err(TcpRendezvousConnectError::ChannelRead)
                         .next_or_else(|| TcpRendezvousConnectError::ChannelClosed)
-                        .with_timeout(Duration::from_secs(20), &handle1)
+                        .with_timeout(
+                            Duration::from_secs(RENDEZVOUS_INFO_EXCHANGE_TIMEOUT_SEC),
+                            &handle1
+                        )
                         .and_then(|opt| opt.ok_or(TcpRendezvousConnectError::ChannelTimedOut))
                     })
                     .and_then(|(msg, _channel)| {

--- a/src/udp/socket.rs
+++ b/src/udp/socket.rs
@@ -9,6 +9,8 @@ use std::error::Error;
 use tokio_shared_udp_socket::{SharedUdpSocket, WithAddress};
 use udp::msg::UdpRendezvousMsg;
 
+const RENDEZVOUS_INFO_EXCHANGE_TIMEOUT_SEC: u64 = 120;
+
 /// Errors returned by `UdpSocketExt::rendezvous_connect`.
 #[derive(Debug)]
 pub enum UdpRendezvousConnectError<Ei, Eo> {
@@ -980,7 +982,10 @@ where
             channel
                 .map_err(UdpRendezvousConnectError::ChannelRead)
                 .next_or_else(|| UdpRendezvousConnectError::ChannelClosed)
-                .with_timeout(Duration::from_secs(20), &handle)
+                .with_timeout(
+                    Duration::from_secs(RENDEZVOUS_INFO_EXCHANGE_TIMEOUT_SEC),
+                    &handle,
+                )
                 .and_then(|opt| opt.ok_or(UdpRendezvousConnectError::ChannelTimedOut))
                 .and_then(|(msg, _channel)| {
                     bincode::deserialize(&msg).map_err(UdpRendezvousConnectError::DeserializeMsg)


### PR DESCRIPTION
With too short timeouts connections might be prematurily dropped - especially with manual tests.

Also, note that this change indicates duplicate code.
It would be really easy to extract it. I simply wonder how to deal with different error types:
```
                        channel
                        .map_err(TcpRendezvousConnectError::ChannelRead)
                        .next_or_else(|| TcpRendezvousConnectError::ChannelClosed)
                        .with_timeout(
                            Duration::from_secs(RENDEZVOUS_INFO_EXCHANGE_TIMEOUT_SEC),
                            &handle1
                        )
                        .and_then(|opt| opt.ok_or(TcpRendezvousConnectError::ChannelTimedOut))
```

In case of `UDP` code is identical except that errors are of `UdpRendezvousConnectError` type.