### PR TITLE
fix/hole-punching: re-send echo requests

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,7 @@ void = "~1.0"
 serde_json = "~1.0"
 
 [target.'cfg(target_os = "linux")'.dependencies]
-netsim = { version = "~0.1.5", optional = true }
+netsim = { version = "~0.1.7", optional = true }
 
 [features]
 default = ["netsim"]

--- a/src/udp/socket.rs
+++ b/src/udp/socket.rs
@@ -1380,7 +1380,7 @@ mod netsim_test {
             spawn_complete
             .resume_unwind()
             .map(|((), (), ())| ())
-            .with_timeout(start_delay + Duration::from_secs(5), &handle)
+            .with_timeout(start_delay + Duration::from_secs(20), &handle)
             .map(|opt| unwrap!(opt, "test timed out!"))
         }));
         res.void_unwrap()


### PR DESCRIPTION
Send rendezvous server echo requests multiple times in case they get dropped.

Update netsim to newer version with bugfix.

Extend timeout on rendezvous connect tests.