### PR TITLE
MAID-3039: fix UDP hole-punching alg for symmetric NATs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,7 @@ safe_crypto = "~0.2.0"
 serde_json = "~1.0"
 
 [target.'cfg(target_os = "linux")'.dependencies]
-netsim = { version = "~0.2.4", optional = true }
+netsim = { version = "~0.2.5", optional = true }
 
 [features]
 default = ["netsim"]

--- a/src/rendezvous_addr.rs
+++ b/src/rendezvous_addr.rs
@@ -1,4 +1,5 @@
 use futures::future::Loop;
+use futures::stream::FuturesOrdered;
 use igd_async::{self, GetAnyAddressError};
 use priv_prelude::*;
 use std::error::Error;
@@ -90,117 +91,201 @@ fn public_addrs_from_stun(
     protocol: Protocol,
     bind_addr: SocketAddr,
 ) -> impl Future<Item = SocketAddr, Error = RendezvousAddrErrorKind> {
-    const NUM_PARALLEL_QUERIES: usize = 3;
-
-    let incoming_addrs = match protocol {
-        Protocol::Tcp => {
-            let handle = handle.clone();
-            p2p.tcp_addr_queriers()
-                .with_readiness_timeout(Duration::from_secs(2), &handle)
-                .infallible()
-                .map(move |addr_querier| addr_querier.query(&bind_addr, &handle))
-                .buffer_unordered(NUM_PARALLEL_QUERIES)
-                .into_boxed()
-        }
-        Protocol::Udp => {
-            let handle = handle.clone();
-            p2p.udp_addr_queriers()
-                .with_readiness_timeout(Duration::from_secs(2), &handle)
-                .infallible()
-                .map(move |addr_querier| addr_querier.query(&bind_addr, &handle))
-                .buffer_unordered(NUM_PARALLEL_QUERIES)
-                .into_boxed()
-        }
+    let querier_stream = {
+        let mut next_query_time = Timeout::new_at(Instant::now(), handle);
+        let mut querier_stream = match protocol {
+            Protocol::Tcp => {
+                let handle = handle.clone();
+                p2p.tcp_addr_queriers()
+                    .with_readiness_timeout(Duration::from_secs(2), &handle)
+                    .infallible()
+                    .map(move |addr_querier| addr_querier.query(&bind_addr, &handle))
+                    .into_boxed()
+            }
+            Protocol::Udp => {
+                let handle = handle.clone();
+                p2p.udp_addr_queriers()
+                    .with_readiness_timeout(Duration::from_secs(2), &handle)
+                    .infallible()
+                    .map(move |addr_querier| addr_querier.query(&bind_addr, &handle))
+                    .into_boxed()
+            }
+        };
+        stream::poll_fn(move || {
+            match next_query_time.poll().void_unwrap() {
+                Async::Ready(()) => (),
+                Async::NotReady => return Ok(Async::NotReady),
+            }
+            match querier_stream.poll().void_unwrap() {
+                Async::Ready(Some(querier)) => {
+                    next_query_time.reset(Instant::now() + Duration::from_millis(100));
+                    Ok(Async::Ready(Some(querier)))
+                }
+                Async::Ready(None) => Ok(Async::Ready(None)),
+                Async::NotReady => Ok(Async::NotReady),
+            }
+        }).into_boxed()
     };
 
     let errors = Vec::new();
-    let known_ip_opt = None;
-    let known_ports = Vec::new();
     future::loop_fn(
-        (errors, known_ip_opt, known_ports, incoming_addrs),
-        move |(mut errors, mut known_ip_opt, mut known_ports, incoming_addrs)| {
-            incoming_addrs.into_future().then(move |res| match res {
-                Err((e, incoming_addrs)) => {
-                    errors.push(e);
+        (querier_stream, errors),
+        move |(querier_stream, mut errors)| {
+            GuessPort::start(querier_stream).and_then(|res| match res {
+                Ok(addr) => Ok(Loop::Break(addr)),
+                Err((querier_stream, error)) => {
+                    errors.push(error);
                     if errors.len() == 5 {
                         return Err(RendezvousAddrErrorKind::HitErrorLimit(errors));
                     }
-                    Ok(Loop::Continue((
-                        errors,
-                        known_ip_opt,
-                        known_ports,
-                        incoming_addrs,
-                    )))
-                }
-                Ok((incoming_addr_opt, incoming_addrs)) => {
-                    let incoming_addr = match incoming_addr_opt {
-                        Some(incoming_addr) => incoming_addr,
-                        None => {
-                            if let Some(known_ip) = known_ip_opt {
-                                return Ok(Loop::Break(SocketAddr::new(known_ip, known_ports[0])));
-                            }
-                            return Err(RendezvousAddrErrorKind::LackOfServers);
-                        }
-                    };
-
-                    known_ports.push(incoming_addr.port());
-                    let known_ip = match known_ip_opt {
-                        Some(known_ip) => known_ip,
-                        None => {
-                            known_ip_opt = Some(incoming_addr.ip());
-                            return Ok(Loop::Continue((
-                                errors,
-                                known_ip_opt,
-                                known_ports,
-                                incoming_addrs,
-                            )));
-                        }
-                    };
-
-                    if known_ip != incoming_addr.ip() {
-                        return Err(RendezvousAddrErrorKind::InconsistentIpAddrs(
-                            known_ip,
-                            incoming_addr.ip(),
-                        ));
-                    }
-
-                    if known_ports.len() == 2 {
-                        if known_ports[0] == known_ports[1] {
-                            return Ok(Loop::Break(SocketAddr::new(known_ip, known_ports[0])));
-                        }
-                        return Ok(Loop::Continue((
-                            errors,
-                            known_ip_opt,
-                            known_ports,
-                            incoming_addrs,
-                        )));
-                    }
-
-                    let num_known_ports = known_ports.len();
-                    let port0 = known_ports[num_known_ports - 3];
-                    let port1 = known_ports[num_known_ports - 2];
-                    let port2 = known_ports[num_known_ports - 1];
-                    let diff0 = port1.wrapping_sub(port0);
-                    let diff1 = port2.wrapping_sub(port1);
-
-                    if diff0 == diff1 {
-                        let port = port2.wrapping_add(diff0);
-                        return Ok(Loop::Break(SocketAddr::new(known_ip, port)));
-                    }
-
-                    if num_known_ports > 5 {
-                        return Err(RendezvousAddrErrorKind::UnpredictablePorts(
-                            port0, port1, port2,
-                        ));
-                    }
-                    Ok(Loop::Continue((
-                        errors,
-                        known_ip_opt,
-                        known_ports,
-                        incoming_addrs,
-                    )))
+                    Ok(Loop::Continue((querier_stream, errors)))
                 }
             })
         },
     )
+}
+
+type QueryFuture = BoxFuture<SocketAddr, Box<Error>>;
+type GuessPortResult = Result<SocketAddr, (BoxStream<QueryFuture, Void>, Box<Error>)>;
+
+struct GuessPort {
+    known_ip_opt: Option<IpAddr>,
+    known_ports: Vec<u16>,
+    active_queriers: FuturesOrdered<QueryFuture>,
+    querier_stream: Option<BoxStream<QueryFuture, Void>>,
+    discarded_ports: u32,
+}
+
+impl GuessPort {
+    fn start(querier_stream: BoxStream<BoxFuture<SocketAddr, Box<Error>>, Void>) -> GuessPort {
+        GuessPort {
+            known_ip_opt: None,
+            known_ports: Vec::new(),
+            active_queriers: FuturesOrdered::new(),
+            querier_stream: Some(querier_stream),
+            discarded_ports: 0,
+        }
+    }
+
+    fn poll_for_more_queriers(&mut self) -> bool {
+        while self.known_ports.len() + self.active_queriers.len() < 3 {
+            match unwrap!(self.querier_stream.as_mut()).poll().void_unwrap() {
+                Async::Ready(Some(querier)) => {
+                    self.active_queriers.push(querier);
+                }
+                Async::Ready(None) => return true,
+                Async::NotReady => break,
+            }
+        }
+        false
+    }
+
+    fn handle_new_address(
+        &mut self,
+        addr: SocketAddr,
+    ) -> Result<Async<SocketAddr>, RendezvousAddrErrorKind> {
+        let received_ip = addr.ip();
+        let known_ip = match self.known_ip_opt {
+            Some(known_ip) => known_ip,
+            None => {
+                self.known_ip_opt = Some(received_ip);
+                received_ip
+            }
+        };
+
+        if received_ip != known_ip {
+            let err = RendezvousAddrErrorKind::InconsistentIpAddrs(received_ip, known_ip);
+            return Err(err);
+        }
+
+        self.known_ports.push(addr.port());
+
+        if self.known_ports.len() == 2 && self.known_ports[0] == self.known_ports[1] {
+            return Ok(Async::Ready(addr));
+        }
+
+        if self.known_ports.len() == 3 {
+            let diff0 = self.known_ports[1].wrapping_sub(self.known_ports[0]);
+            let diff1 = self.known_ports[2].wrapping_sub(self.known_ports[1]);
+            if diff0 == diff1 {
+                let next_port = self.known_ports[2].wrapping_add(diff0);
+                let addr = SocketAddr::new(known_ip, next_port);
+                return Ok(Async::Ready(addr));
+            }
+
+            if self.discarded_ports == 5 {
+                let err = RendezvousAddrErrorKind::UnpredictablePorts(
+                    self.known_ports[0],
+                    self.known_ports[1],
+                    self.known_ports[2],
+                );
+                return Err(err);
+            }
+
+            let _ = self.known_ports.remove(0);
+            self.discarded_ports += 1;
+        }
+
+        Ok(Async::NotReady)
+    }
+
+    fn queriers_exhausted(&mut self) -> Result<SocketAddr, RendezvousAddrErrorKind> {
+        info!("Unable to contact enough query servers to hole-punch reliably.");
+        let known_ip = match self.known_ip_opt {
+            Some(known_ip) => known_ip,
+            None => {
+                let err = RendezvousAddrErrorKind::LackOfServers;
+                return Err(err);
+            }
+        };
+        match self.known_ports.len() {
+            0 => unreachable!(), // since we have known_ip we must have gotten a port
+            1 => {
+                info!("Guessing port based on only one response.");
+                Ok(SocketAddr::new(known_ip, self.known_ports[0]))
+            }
+            2 => {
+                info!("Guessing port based on only two responses.");
+                let diff = self.known_ports[1].wrapping_sub(self.known_ports[0]);
+                let next_port = self.known_ports[1].wrapping_add(diff);
+                Ok(SocketAddr::new(known_ip, next_port))
+            }
+            3 => {
+                let err = RendezvousAddrErrorKind::UnpredictablePorts(
+                    self.known_ports[0],
+                    self.known_ports[1],
+                    self.known_ports[2],
+                );
+                Err(err)
+            }
+            _ => unreachable!(), // we never collect more than 3 ports,
+        }
+    }
+}
+
+impl Future for GuessPort {
+    type Item = GuessPortResult;
+    type Error = RendezvousAddrErrorKind;
+
+    fn poll(&mut self) -> Result<Async<GuessPortResult>, RendezvousAddrErrorKind> {
+        loop {
+            let querier_stream_exhausted = self.poll_for_more_queriers();
+
+            match self.active_queriers.poll() {
+                Ok(Async::Ready(Some(addr))) => match self.handle_new_address(addr)? {
+                    Async::Ready(addr) => return Ok(Async::Ready(Ok(addr))),
+                    Async::NotReady => (),
+                },
+                Ok(Async::Ready(None)) => {
+                    if querier_stream_exhausted {
+                        let addr = self.queriers_exhausted()?;
+                        return Ok(Async::Ready(Ok(addr)));
+                    }
+                    return Ok(Async::NotReady);
+                }
+                Ok(Async::NotReady) => return Ok(Async::NotReady),
+                Err(e) => return Ok(Async::Ready(Err((unwrap!(self.querier_stream.take()), e)))),
+            }
+        }
+    }
 }

--- a/src/udp/socket.rs
+++ b/src/udp/socket.rs
@@ -1424,7 +1424,6 @@ mod netsim_test {
         );
     }
 
-    #[ignore] // currently fails :(
     #[test]
     fn udp_rendezvous_connect_between_natted_hosts_one_symmetric_with_no_delay_many_servers() {
         udp_rendezvous_connect_between_natted_hosts(
@@ -1438,7 +1437,6 @@ mod netsim_test {
         );
     }
 
-    #[ignore] // currently fails :(
     #[test]
     fn udp_rendezvous_connect_between_natted_hosts_both_symmetric_with_no_delay() {
         udp_rendezvous_connect_between_natted_hosts(
@@ -1494,7 +1492,6 @@ mod netsim_test {
         );
     }
 
-    #[ignore] // currently fails :(
     #[test]
     fn udp_rendezvous_connect_between_natted_hosts_one_symmetric_with_short_delay_many_servers() {
         udp_rendezvous_connect_between_natted_hosts(
@@ -1549,7 +1546,6 @@ mod netsim_test {
         );
     }
 
-    #[ignore] // currently fails :(
     #[test]
     fn udp_rendezvous_connect_between_natted_hosts_one_symmetric_with_long_delay_many_servers() {
         udp_rendezvous_connect_between_natted_hosts(


### PR DESCRIPTION
This splits the algorithm into two smaller functions. It also makes sure we don't accidentally start any echo queries that we have no intention of waiting for the result of since this screws up our port guess.