### PR TITLE
use rendezvous_addr for UdpSocket::rendezvous_connect

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,9 @@ language: rust
 rust:
   - 1.28.0
   - nightly-2018-07-07
+matrix:
+  allow_failures:
+    - rust: nightly-2018-07-07
 sudo: false
 cache:
   cargo: true


### PR DESCRIPTION
UdpSocket::rendezvous_connect() used to use UdpSocket::bind_public() which uses IGD to add port mappings to your router. Unfortunately bind_public() uses open_addr() which doesn't respect igd_disabled_for_rendezvous option, hence IGD in this case couldn't be turned off. rendezvous_addr() does basically the same as open_addr() which attempts IGD to add port mapping, if fails, checks if our router is full cone in which case it's easy to find our public endpoint. This is minimal change that only uses rendezvous_addr() which respects igd_disabled_for_rendezvous option but acts the same.

NOTE that rendezvous_addr() and open_addr() are super similar and we should review how to deduplicate code in the future.